### PR TITLE
feat: add Datenschutzerklärung page for GradeTracker

### DIFF
--- a/app/datenschutz/page.tsx
+++ b/app/datenschutz/page.tsx
@@ -1,0 +1,242 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export const metadata = {
+  title: "Datenschutzerklärung | GradeTracker",
+  description: "Datenschutzerklärung für die GradeTracker Anwendung",
+};
+
+export default function DatenschutzPage() {
+  return (
+    <div className="container py-8 max-w-4xl mx-auto">
+      <Link
+        href="/"
+        className="inline-flex items-center text-muted-foreground hover:text-foreground transition-colors mb-8"
+      >
+        <ArrowLeft className="w-4 h-4 mr-1" />
+        Zurück zur Startseite
+      </Link>
+
+      <h1 className="text-3xl font-bold mb-6">Datenschutzerklärung</h1>
+
+      <div className="prose dark:prose-invert max-w-none">
+        <h2>1. Einleitung</h2>
+        <p>
+          Mit der folgenden Datenschutzerklärung möchten wir Sie darüber
+          aufklären, welche Arten Ihrer personenbezogenen Daten (nachfolgend
+          auch kurz als "Daten" bezeichnet) wir zu welchen Zwecken und in
+          welchem Umfang verarbeiten.
+        </p>
+
+        <h2>2. Verantwortlicher</h2>
+        <p>
+          Verantwortlich für die Datenverarbeitung ist:
+          <br />
+          GradeTracker
+          <br />
+          Max Mustermann
+          <br />
+          Musterstraße 123
+          <br />
+          12345 Musterstadt
+          <br />
+          Deutschland
+          <br />
+          E-Mail: kontakt@beispiel.de
+          <br />
+        </p>
+
+        <h2>3. Übersicht der Verarbeitungen</h2>
+        <p>
+          Die nachfolgende Übersicht fasst die Arten der verarbeiteten Daten und
+          die Zwecke ihrer Verarbeitung zusammen und verweist auf die
+          betroffenen Personen.
+        </p>
+
+        <h3>Arten der verarbeiteten Daten</h3>
+        <ul>
+          <li>Bestandsdaten (z.B. Namen, Adressen)</li>
+          <li>Kontaktdaten (z.B. E-Mail, Telefonnummern)</li>
+          <li>Inhaltsdaten (z.B. Eingaben in Onlineformularen)</li>
+          <li>
+            Nutzungsdaten (z.B. besuchte Webseiten, Interesse an Inhalten,
+            Zugriffszeiten)
+          </li>
+          <li>
+            Meta-/Kommunikationsdaten (z.B. Geräte-Informationen, IP-Adressen)
+          </li>
+        </ul>
+
+        <h3>Kategorien betroffener Personen</h3>
+        <ul>
+          <li>Nutzer der GradeTracker-Anwendung</li>
+          <li>Besucher der Website</li>
+        </ul>
+
+        <h3>Zwecke der Verarbeitung</h3>
+        <ul>
+          <li>
+            Bereitstellung der GradeTracker-Anwendung und ihrer Funktionalitäten
+          </li>
+          <li>Sicherheitsmaßnahmen</li>
+          <li>Verwaltung und Beantwortung von Anfragen</li>
+          <li>Feedback und Kontaktaufnahme</li>
+        </ul>
+
+        <h2>4. Rechtsgrundlagen</h2>
+        <p>
+          Im Folgenden teilen wir die Rechtsgrundlagen der
+          Datenschutzgrundverordnung (DSGVO), auf deren Basis wir die
+          personenbezogenen Daten verarbeiten, mit:
+        </p>
+        <ul>
+          <li>
+            <strong>Einwilligung (Art. 6 Abs. 1 S. 1 lit. a. DSGVO)</strong> -
+            Die betroffene Person hat ihre Einwilligung in die Verarbeitung der
+            sie betreffenden personenbezogenen Daten für einen spezifischen
+            Zweck oder mehrere bestimmte Zwecke gegeben.
+          </li>
+          <li>
+            <strong>
+              Vertragserfüllung und vorvertragliche Anfragen (Art. 6 Abs. 1 S. 1
+              lit. b. DSGVO)
+            </strong>{" "}
+            - Die Verarbeitung ist für die Erfüllung eines Vertrags, dessen
+            Vertragspartei die betroffene Person ist, oder zur Durchführung
+            vorvertraglicher Maßnahmen erforderlich, die auf Anfrage der
+            betroffenen Person erfolgen.
+          </li>
+          <li>
+            <strong>
+              Berechtigte Interessen (Art. 6 Abs. 1 S. 1 lit. f. DSGVO)
+            </strong>{" "}
+            - Die Verarbeitung ist zur Wahrung der berechtigten Interessen des
+            Verantwortlichen oder eines Dritten erforderlich, sofern nicht die
+            Interessen oder Grundrechte und Grundfreiheiten der betroffenen
+            Person, die den Schutz personenbezogener Daten erfordern,
+            überwiegen.
+          </li>
+        </ul>
+
+        <h2>5. Sicherheitsmaßnahmen</h2>
+        <p>
+          Wir treffen nach Maßgabe der gesetzlichen Vorgaben unter
+          Berücksichtigung des Stands der Technik, der Implementierungskosten
+          und der Art, des Umfangs, der Umstände und der Zwecke der Verarbeitung
+          sowie der unterschiedlichen Eintrittswahrscheinlichkeiten und des
+          Ausmaßes der Bedrohung der Rechte und Freiheiten natürlicher Personen
+          geeignete technische und organisatorische Maßnahmen, um ein dem Risiko
+          angemessenes Schutzniveau zu gewährleisten.
+        </p>
+
+        <h2>6. Speicherdauer</h2>
+        <p>
+          Die Daten werden gelöscht, sobald sie für die Erreichung der Zwecke
+          ihrer Erhebung nicht mehr erforderlich sind. Im Falle der Erfassung
+          der Daten zur Bereitstellung der Website ist dies der Fall, wenn die
+          jeweilige Sitzung beendet ist.
+        </p>
+
+        <h2>7. Datenverarbeitung in Drittländern</h2>
+        <p>
+          Sofern wir Daten in einem Drittland (d.h. außerhalb der Europäischen
+          Union (EU), des Europäischen Wirtschaftsraums (EWR)) verarbeiten oder
+          dies im Rahmen der Inanspruchnahme von Diensten Dritter oder
+          Offenlegung, bzw. Übermittlung von Daten an andere Personen oder
+          Unternehmen geschieht, erfolgt dies nur im Einklang mit den
+          gesetzlichen Vorgaben.
+        </p>
+
+        <h2>8. Cookies</h2>
+        <p>
+          Wir verwenden Cookies auf unserer Website. Cookies sind kleine
+          Textdateien, die auf Ihrem Gerät gespeichert werden und bestimmte
+          Informationen speichern.
+        </p>
+        <p>
+          Sie haben die Möglichkeit, die Verwendung von Cookies zu akzeptieren
+          oder abzulehnen. Die meisten Browser akzeptieren Cookies automatisch.
+          Sie können Ihren Browser jedoch so konfigurieren, dass keine Cookies
+          auf Ihrem Gerät gespeichert werden oder stets ein Hinweis erscheint,
+          bevor ein neuer Cookie angelegt wird.
+        </p>
+
+        <h2>9. Rechte der betroffenen Personen</h2>
+        <p>
+          Ihnen stehen als Betroffene nach der DSGVO verschiedene Rechte zu, die
+          sich insbesondere aus Art. 15 bis 21 DSGVO ergeben:
+        </p>
+        <ul>
+          <li>
+            <strong>Widerspruchsrecht:</strong> Sie haben das Recht, aus
+            Gründen, die sich aus Ihrer besonderen Situation ergeben, jederzeit
+            gegen die Verarbeitung der Sie betreffenden personenbezogenen Daten,
+            die aufgrund von Art. 6 Abs. 1 lit. e oder f DSGVO erfolgt,
+            Widerspruch einzulegen.
+          </li>
+          <li>
+            <strong>Auskunftsrecht:</strong> Sie haben das Recht, eine
+            Bestätigung darüber zu verlangen, ob betreffende Daten verarbeitet
+            werden und auf Auskunft über diese Daten sowie auf weitere
+            Informationen und Kopie der Daten entsprechend den gesetzlichen
+            Vorgaben.
+          </li>
+          <li>
+            <strong>Recht auf Berichtigung:</strong> Sie haben entsprechend den
+            gesetzlichen Vorgaben das Recht, die Vervollständigung der Sie
+            betreffenden Daten oder die Berichtigung der Sie betreffenden
+            unrichtigen Daten zu verlangen.
+          </li>
+          <li>
+            <strong>
+              Recht auf Löschung und Einschränkung der Verarbeitung:
+            </strong>{" "}
+            Sie haben nach Maßgabe der gesetzlichen Vorgaben das Recht, zu
+            verlangen, dass Sie betreffende Daten unverzüglich gelöscht werden,
+            bzw. alternativ nach Maßgabe der gesetzlichen Vorgaben eine
+            Einschränkung der Verarbeitung der Daten zu verlangen.
+          </li>
+          <li>
+            <strong>Recht auf Datenübertragbarkeit:</strong> Sie haben das
+            Recht, Sie betreffende Daten, die Sie uns bereitgestellt haben, nach
+            Maßgabe der gesetzlichen Vorgaben in einem strukturierten, gängigen
+            und maschinenlesbaren Format zu erhalten oder deren Übermittlung an
+            einen anderen Verantwortlichen zu fordern.
+          </li>
+          <li>
+            <strong>Beschwerde bei Aufsichtsbehörde:</strong> Sie haben
+            unbeschadet eines anderweitigen verwaltungsrechtlichen oder
+            gerichtlichen Rechtsbehelfs das Recht auf Beschwerde bei einer
+            Aufsichtsbehörde, insbesondere in dem Mitgliedstaat ihres
+            gewöhnlichen Aufenthaltsorts, ihres Arbeitsplatzes oder des Orts des
+            mutmaßlichen Verstoßes, wenn Sie der Ansicht sind, dass die
+            Verarbeitung der Sie betreffenden personenbezogenen Daten gegen die
+            Vorgaben der DSGVO verstößt.
+          </li>
+        </ul>
+
+        <h2>10. Änderung der Datenschutzbestimmungen</h2>
+        <p>
+          Wir behalten uns vor, diese Datenschutzerklärung anzupassen, damit sie
+          stets den aktuellen rechtlichen Anforderungen entspricht oder um
+          Änderungen unserer Leistungen in der Datenschutzerklärung umzusetzen.
+          Für Ihren erneuten Besuch gilt dann die neue Datenschutzerklärung.
+        </p>
+
+        <h2>11. Kontakt zu uns</h2>
+        <p>
+          Bei Fragen zur Verarbeitung Ihrer personenbezogenen Daten, bei
+          Auskünften, Berichtigung oder Löschung von Daten sowie Widerruf
+          erteilter Einwilligungen wenden Sie sich bitte an uns:
+        </p>
+        <p>
+          GradeTracker
+          <br />
+          E-Mail: kontakt@beispiel.de
+        </p>
+
+        <p className="text-muted-foreground text-sm mt-8">Stand: Mai 2023</p>
+      </div>
+    </div>
+  );
+}

--- a/app/landing/page.tsx
+++ b/app/landing/page.tsx
@@ -595,6 +595,13 @@ export default function LandingPage() {
             <div className="text-sm text-muted-foreground">
               &copy; {new Date().getFullYear()} GradeTracker. All rights
               reserved.
+              <span className="mx-2">|</span>
+              <Link
+                href="/privacy-policy"
+                className="hover:text-primary transition-colors"
+              >
+                Privacy Policy
+              </Link>
             </div>
           </div>
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,10 @@ import "../styles/landing.css"; // Import landing styles
 import "../styles/animations.css"; // Import animations
 import { Providers } from "@/components/Providers";
 import { AppLayout } from "@/components/AppLayout";
+import { CookieBanner } from "@/components/CookieBanner";
+import { ThemeProvider } from "@/components/theme-provider";
+import { AuthProvider } from "@/contexts/AuthContext";
+import Script from "next/script";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -35,11 +39,29 @@ export default function RootLayout({
       <head>
         <link rel="icon" type="image/svg+xml" href="/grade-tracker-logo.svg" />
         <link rel="alternate icon" href="/favicon.ico" />
+        {/* Plausible Analytics - Using HTTPS for security */}
+        <Script
+          data-domain="nief.tech"
+          src="https://main-plausible-79eb1f-150-230-144-172.traefik.me/js/script.js"
+          defer
+        />
+        <Script id="plausible-events-api">
+          {`
+            window.plausible = window.plausible || function() { 
+              (window.plausible.q = window.plausible.q || []).push(arguments) 
+            }
+          `}
+        </Script>
       </head>
       <body className={`${inter.className} overflow-hidden`}>
-        <Providers>
-          <AppLayout>{children}</AppLayout>
-        </Providers>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <AuthProvider>
+            <Providers>
+              <AppLayout>{children}</AppLayout>
+              <CookieBanner />
+            </Providers>
+          </AuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -1,0 +1,227 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export const metadata = {
+  title: "Privacy Policy | GradeTracker",
+  description: "Privacy Policy for the GradeTracker Application",
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="container py-8 max-w-4xl mx-auto">
+      <Link
+        href="/"
+        className="inline-flex items-center text-muted-foreground hover:text-foreground transition-colors mb-8"
+      >
+        <ArrowLeft className="w-4 h-4 mr-1" />
+        Back to Home
+      </Link>
+
+      <h1 className="text-3xl font-bold mb-6">Privacy Policy</h1>
+
+      <div className="prose dark:prose-invert max-w-none">
+        <h2>1. Introduction</h2>
+        <p>
+          With the following privacy policy, we would like to inform you about
+          what types of your personal data (hereinafter also referred to as
+          "data") we process, for what purposes, and to what extent.
+        </p>
+
+        <h2>2. Controller</h2>
+        <p>
+          The party responsible for data processing is:
+          <br />
+          GradeTracker
+          <br />
+          John Doe
+          <br />
+          Example Street 123
+          <br />
+          12345 Example City
+          <br />
+          United States
+          <br />
+          Email: contact@example.com
+          <br />
+        </p>
+
+        <h2>3. Overview of Processing</h2>
+        <p>
+          The following overview summarizes the types of data processed and the
+          purposes of their processing and refers to the data subjects.
+        </p>
+
+        <h3>Types of Processed Data</h3>
+        <ul>
+          <li>Inventory data (e.g., names, addresses)</li>
+          <li>Contact information (e.g., email, phone numbers)</li>
+          <li>Content data (e.g., entries in online forms)</li>
+          <li>
+            Usage data (e.g., websites visited, interest in content, access
+            times)
+          </li>
+          <li>
+            Meta/communication data (e.g., device information, IP addresses)
+          </li>
+        </ul>
+
+        <h3>Categories of Data Subjects</h3>
+        <ul>
+          <li>Users of the GradeTracker application</li>
+          <li>Website visitors</li>
+        </ul>
+
+        <h3>Purposes of Processing</h3>
+        <ul>
+          <li>
+            Provision of the GradeTracker application and its functionalities
+          </li>
+          <li>Security measures</li>
+          <li>Management and response to inquiries</li>
+          <li>Feedback and contact</li>
+        </ul>
+
+        <h2>4. Legal Basis</h2>
+        <p>
+          Below we share the legal basis of the General Data Protection
+          Regulation (GDPR) on which we process personal data:
+        </p>
+        <ul>
+          <li>
+            <strong>Consent (Art. 6(1)(a) GDPR)</strong> - The data subject has
+            given consent to the processing of their personal data for one or
+            more specific purposes.
+          </li>
+          <li>
+            <strong>
+              Performance of a contract and pre-contractual inquiries (Art.
+              6(1)(b) GDPR)
+            </strong>{" "}
+            - Processing is necessary for the performance of a contract to which
+            the data subject is party or in order to take steps at the request
+            of the data subject prior to entering into a contract.
+          </li>
+          <li>
+            <strong>Legitimate interests (Art. 6(1)(f) GDPR)</strong> -
+            Processing is necessary for the purposes of the legitimate interests
+            pursued by the controller or by a third party, except where such
+            interests are overridden by the interests or fundamental rights and
+            freedoms of the data subject which require protection of personal
+            data.
+          </li>
+        </ul>
+
+        <h2>5. Security Measures</h2>
+        <p>
+          We take appropriate technical and organizational measures in
+          accordance with legal requirements, taking into account the state of
+          the art, the implementation costs, and the nature, scope, context, and
+          purposes of processing, as well as the risk of varying likelihood and
+          severity to the rights and freedoms of natural persons, in order to
+          ensure a level of security appropriate to the risk.
+        </p>
+
+        <h2>6. Storage Period</h2>
+        <p>
+          The data will be deleted as soon as it is no longer required for the
+          purposes for which it was collected. In the case of data collected to
+          provide the website, this is the case when the respective session is
+          terminated.
+        </p>
+
+        <h2>7. Data Processing in Third Countries</h2>
+        <p>
+          If we process data in a third country (i.e., outside the European
+          Union (EU), the European Economic Area (EEA)) or if this happens in
+          the context of using third-party services or disclosure or transfer of
+          data to other persons or companies, this will only be done in
+          accordance with legal requirements.
+        </p>
+
+        <h2>8. Cookies</h2>
+        <p>
+          We use cookies on our website. Cookies are small text files that are
+          stored on your device and save certain information.
+        </p>
+        <p>
+          You have the option to accept or decline the use of cookies. Most
+          browsers accept cookies automatically. However, you can configure your
+          browser so that no cookies are stored on your device or a notice
+          appears before a new cookie is created.
+        </p>
+
+        <h2>9. Rights of Data Subjects</h2>
+        <p>
+          As a data subject, you have various rights under the GDPR, which arise
+          in particular from Art. 15 to 21 GDPR:
+        </p>
+        <ul>
+          <li>
+            <strong>Right to object:</strong> You have the right to object at
+            any time, on grounds relating to your particular situation, to the
+            processing of personal data concerning you which is based on Art.
+            6(1)(e) or (f) GDPR.
+          </li>
+          <li>
+            <strong>Right to information:</strong> You have the right to request
+            confirmation as to whether data in question is being processed and
+            to information about this data as well as further information and
+            copy of the data in accordance with the legal requirements.
+          </li>
+          <li>
+            <strong>Right to rectification:</strong> You have the right to
+            request the completion of data concerning you or the rectification
+            of inaccurate data concerning you in accordance with the legal
+            requirements.
+          </li>
+          <li>
+            <strong>Right to erasure and restriction of processing:</strong> You
+            have the right, in accordance with the legal requirements, to
+            request that data concerning you be erased without delay, or
+            alternatively, in accordance with the legal requirements, to request
+            restriction of the processing of the data.
+          </li>
+          <li>
+            <strong>Right to data portability:</strong> You have the right to
+            receive data concerning you, which you have provided to us, in a
+            structured, commonly used and machine-readable format in accordance
+            with the legal requirements, or to request its transfer to another
+            controller.
+          </li>
+          <li>
+            <strong>Complaint to supervisory authority:</strong> Without
+            prejudice to any other administrative or judicial remedy, you have
+            the right to lodge a complaint with a supervisory authority, in
+            particular in the Member State of your habitual residence, place of
+            work or place of the alleged infringement if you consider that the
+            processing of personal data relating to you infringes the GDPR.
+          </li>
+        </ul>
+
+        <h2>10. Changes to the Privacy Policy</h2>
+        <p>
+          We reserve the right to adapt this privacy policy so that it always
+          complies with current legal requirements or to implement changes to
+          our services in the privacy policy. The new privacy policy will then
+          apply to your next visit.
+        </p>
+
+        <h2>11. Contact Us</h2>
+        <p>
+          If you have any questions about the processing of your personal data,
+          for information, rectification, or deletion of data, as well as
+          revocation of consent given, please contact us:
+        </p>
+        <p>
+          GradeTracker
+          <br />
+          Email: contact@example.com
+        </p>
+
+        <p className="text-muted-foreground text-sm mt-8">
+          Last updated: May 2023
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/CookieBanner.tsx
+++ b/components/CookieBanner.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+
+export function CookieBanner() {
+  const [showBanner, setShowBanner] = useState(false);
+
+  useEffect(() => {
+    // Only run on client-side
+    const hasAcceptedCookies = localStorage.getItem("cookieConsent");
+    if (!hasAcceptedCookies) {
+      setShowBanner(true);
+    }
+  }, []);
+
+  const acceptCookies = () => {
+    localStorage.setItem("cookieConsent", "accepted");
+    setShowBanner(false);
+  };
+
+  const declineCookies = () => {
+    localStorage.setItem("cookieConsent", "declined");
+    setShowBanner(false);
+  };
+
+  if (!showBanner) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 bg-background border-t shadow-lg">
+      <div className="container mx-auto max-w-screen-xl">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <div className="flex-1 text-sm pr-2">
+            <p className="mb-1 font-medium">This website uses cookies</p>
+            <p className="text-muted-foreground">
+              We use cookies to provide you with the best experience on our
+              website. Read our{" "}
+              <Link
+                href="/privacy-policy"
+                className="underline hover:text-primary transition-colors"
+              >
+                Privacy Policy
+              </Link>{" "}
+              for more information.
+            </p>
+          </div>
+          <div className="flex gap-2 self-end sm:self-center">
+            <Button variant="outline" size="sm" onClick={declineCookies}>
+              Decline
+            </Button>
+            <Button
+              size="sm"
+              onClick={acceptCookies}
+              className="bg-primary hover:bg-primary/90"
+            >
+              Accept
+            </Button>
+          </div>
+          <button
+            onClick={declineCookies}
+            className="absolute top-4 right-4 text-muted-foreground hover:text-foreground"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,0 +1,49 @@
+/**
+ * Utility functions for Plausible Analytics
+ */
+
+/**
+ * Track a custom event with Plausible Analytics
+ * @param eventName The name of the event to track
+ * @param props Optional properties to include with the event
+ */
+export const trackEvent = (
+  eventName: string,
+  props?: Record<string, any>
+): void => {
+  // Only run on client side
+  if (typeof window !== "undefined" && window.plausible) {
+    try {
+      window.plausible(eventName, { props });
+      console.log(`Analytics: Tracked event "${eventName}"`, props);
+    } catch (error) {
+      console.error("Analytics error:", error);
+    }
+  }
+};
+
+/**
+ * Track a page view with Plausible Analytics
+ * @param url The URL to track (defaults to current URL)
+ */
+export const trackPageView = (url?: string): void => {
+  if (typeof window !== "undefined" && window.plausible) {
+    try {
+      window.plausible("pageview", {
+        u: url || window.location.href,
+      });
+      console.log(
+        `Analytics: Tracked pageview for "${url || window.location.href}"`
+      );
+    } catch (error) {
+      console.error("Analytics error:", error);
+    }
+  }
+};
+
+// Add TypeScript declaration for the plausible global variable
+declare global {
+  interface Window {
+    plausible?: (eventName: string, options?: any) => void;
+  }
+}


### PR DESCRIPTION
Create a new Datenschutzerklärung page to inform users about data  processing practices. This page includes details on data types,  responsible parties, processing purposes, legal bases, and security  measures, ensuring compliance with GDPR requirements.