### PR TITLE
feat(analytics): implement page view tracking and consent events

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,8 @@ import { CookieBanner } from "@/components/CookieBanner";
 import { ThemeProvider } from "@/components/theme-provider";
 import { AuthProvider } from "@/contexts/AuthContext";
 import Script from "next/script";
+import { AnalyticsProvider } from "@/components/AnalyticsProvider";
+import { PLAUSIBLE_URL, PLAUSIBLE_DOMAIN } from "@/config/analytics";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -39,13 +41,13 @@ export default function RootLayout({
       <head>
         <link rel="icon" type="image/svg+xml" href="/grade-tracker-logo.svg" />
         <link rel="alternate icon" href="/favicon.ico" />
-        {/* Plausible Analytics - Using HTTPS for security */}
+        {/* Plausible Analytics */}
         <Script
-          data-domain="nief.tech"
-          src="https://main-plausible-79eb1f-150-230-144-172.traefik.me/js/script.js"
-          defer
+          src={`${PLAUSIBLE_URL}/js/script.js`}
+          data-domain={PLAUSIBLE_DOMAIN}
+          strategy="afterInteractive"
         />
-        <Script id="plausible-events-api">
+        <Script id="plausible-events-api" strategy="afterInteractive">
           {`
             window.plausible = window.plausible || function() { 
               (window.plausible.q = window.plausible.q || []).push(arguments) 
@@ -57,8 +59,10 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <AuthProvider>
             <Providers>
-              <AppLayout>{children}</AppLayout>
-              <CookieBanner />
+              <AnalyticsProvider>
+                <AppLayout>{children}</AppLayout>
+                <CookieBanner />
+              </AnalyticsProvider>
             </Providers>
           </AuthProvider>
         </ThemeProvider>

--- a/components/AnalyticsProvider.tsx
+++ b/components/AnalyticsProvider.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+import { trackPageView } from "@/utils/analytics";
+
+export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Track page views
+  useEffect(() => {
+    // Only track when pathname is available
+    if (pathname) {
+      // Include search parameters if present
+      let url = pathname;
+      const search = searchParams?.toString();
+      if (search) url += `?${search}`;
+
+      // Track page view
+      trackPageView(url);
+    }
+  }, [pathname, searchParams]);
+
+  return <>{children}</>;
+}

--- a/components/CookieBanner.tsx
+++ b/components/CookieBanner.tsx
@@ -19,11 +19,21 @@ export function CookieBanner() {
   const acceptCookies = () => {
     localStorage.setItem("cookieConsent", "accepted");
     setShowBanner(false);
+
+    // If Plausible is available, notify it about the consent
+    if (typeof window !== "undefined" && window.plausible) {
+      window.plausible("Consent: Accepted");
+    }
   };
 
   const declineCookies = () => {
     localStorage.setItem("cookieConsent", "declined");
     setShowBanner(false);
+
+    // Respect user preference immediately
+    if (typeof window !== "undefined" && window.plausible) {
+      window.plausible("Consent: Declined");
+    }
   };
 
   if (!showBanner) return null;

--- a/config/analytics.ts
+++ b/config/analytics.ts
@@ -1,0 +1,25 @@
+/**
+ * Plausible Analytics configuration
+ */
+
+// Your Plausible instance URL (use HTTPS)
+export const PLAUSIBLE_URL = "https://plausible.nief.tech";
+
+// Domain being tracked - change this to your actual domain
+export const PLAUSIBLE_DOMAIN = "nief.tech";
+
+// Enable/disable analytics in development
+export const ANALYTICS_ENABLED_IN_DEV = false;
+
+// Check if analytics should be enabled
+export const isAnalyticsEnabled = () => {
+  if (typeof window === "undefined") return false;
+  if (process.env.NODE_ENV === "development" && !ANALYTICS_ENABLED_IN_DEV)
+    return false;
+
+  // Check if user has opted out (from your cookie consent)
+  const cookieConsent = localStorage.getItem("cookieConsent");
+  if (cookieConsent === "declined") return false;
+
+  return true;
+};

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,6 +1,7 @@
 /**
  * Utility functions for Plausible Analytics
  */
+import { isAnalyticsEnabled, PLAUSIBLE_DOMAIN } from "@/config/analytics";
 
 /**
  * Track a custom event with Plausible Analytics
@@ -11,11 +12,17 @@ export const trackEvent = (
   eventName: string,
   props?: Record<string, any>
 ): void => {
-  // Only run on client side
+  // Only run if analytics is enabled
+  if (!isAnalyticsEnabled()) return;
+
   if (typeof window !== "undefined" && window.plausible) {
     try {
       window.plausible(eventName, { props });
-      console.log(`Analytics: Tracked event "${eventName}"`, props);
+
+      // Only log in development
+      if (process.env.NODE_ENV === "development") {
+        console.log(`Analytics: Tracked event "${eventName}"`, props);
+      }
     } catch (error) {
       console.error("Analytics error:", error);
     }
@@ -27,14 +34,21 @@ export const trackEvent = (
  * @param url The URL to track (defaults to current URL)
  */
 export const trackPageView = (url?: string): void => {
+  // Only run if analytics is enabled
+  if (!isAnalyticsEnabled()) return;
+
   if (typeof window !== "undefined" && window.plausible) {
     try {
       window.plausible("pageview", {
         u: url || window.location.href,
       });
-      console.log(
-        `Analytics: Tracked pageview for "${url || window.location.href}"`
-      );
+
+      // Only log in development
+      if (process.env.NODE_ENV === "development") {
+        console.log(
+          `Analytics: Tracked pageview for "${url || window.location.href}"`
+        );
+      }
     } catch (error) {
       console.error("Analytics error:", error);
     }


### PR DESCRIPTION
Add an `AnalyticsProvider` component to track page views using  Plausible Analytics. Integrate it into the layout to ensure  analytics are recorded on route changes. Update the `trackEvent`  and `trackPageView` functions to check if analytics are enabled  before executing. Enhance the `CookieBanner` to notify Plausible  of user consent decisions. Adjust the Plausible script loading  to use configuration values for better maintainability.